### PR TITLE
Add missing requirement

### DIFF
--- a/nidmresults/objects/inference.py
+++ b/nidmresults/objects/inference.py
@@ -12,8 +12,8 @@ import os
 from constants import *
 import shutil
 from generic import *
-from scipy.stats import norm
 import uuid
+from math import erf, sqrt
 
 
 class Inference(NIDMObject):
@@ -647,11 +647,13 @@ class Peak(NIDMObject):
         """
         self.add_object(self.coordinate)
 
+        norm_cdf_z = (1.0 + erf(self.equiv_z / sqrt(2.0))) / 2.0
+
         self.add_attributes([
             (PROV['type'], self.type),
             (PROV['label'], "Peak " + str(self.num)),
             (NIDM_EQUIVALENT_ZSTATISTIC, self.equiv_z),
-            (NIDM_P_VALUE_UNCORRECTED, 1 - norm.cdf(self.equiv_z)),
+            (NIDM_P_VALUE_UNCORRECTED, 1 - norm_cdf_z),
             (PROV['location'], self.coordinate.id)])
 
         return self.p

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ rdflib>=4.2.0
 prov>=1.0.0
 nibabel
 numpy
-scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ rdflib>=4.2.0
 prov>=1.0.0
 nibabel
 numpy
+scipy

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,8 @@ from setuptools import setup, find_packages
 
 readme = open('README.rst').read()
 
-# reqs = [line.strip() for line in open('requirements.txt').readlines()]
-# requirements = list(filter(None, reqs))
-
-requirements = [
-    'rdflib>=4.2.0',
-    'prov>=1.0.0',
-    'nibabel',
-    'numpy'
-]
-
-print requirements
+reqs = [line.strip() for line in open('requirements.txt').readlines()]
+requirements = list(filter(None, reqs))
 
 setup(
     name="nidmresults",

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,18 @@ from setuptools import setup, find_packages
 
 readme = open('README.rst').read()
 
-reqs = [line.strip() for line in open('requirements.txt').readlines()]
-requirements = list(filter(None, reqs))
+# reqs = [line.strip() for line in open('requirements.txt').readlines()]
+# requirements = list(filter(None, reqs))
+
+requirements = [
+    'rdflib>=4.2.0',
+    'prov>=1.0.0',
+    'scipy',
+    'nibabel',
+    'numpy'
+]
+
+print requirements
 
 setup(
     name="nidmresults",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ readme = open('README.rst').read()
 requirements = [
     'rdflib>=4.2.0',
     'prov>=1.0.0',
-    'scipy',
     'nibabel',
     'numpy'
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
 readme = open('README.rst').read()
 
-install_reqs = parse_requirements('requirements.txt')
-requirements = [str(ir.req) for ir in install_reqs]
+reqs = [line.strip() for line in open('requirements.txt').readlines()]
+requirements = list(filter(None, reqs))
 
 setup(
     name="nidmresults",


### PR DESCRIPTION
Using https://github.com/incf-nidash/nidm-results_fsl/pull/42, this pull request add missing requirements for `nidmresults`. 

Also, use of `parse_requirements` is removed from `setup.py` to avoid issue with different versions of pip (`parse_requirements` was not supported for pip < 1.4 and require two arguments for pip 6.0.7 ).