### PR TITLE
Convert to json at time of the export

### DIFF
--- a/nidmresults/objects/generic.py
+++ b/nidmresults/objects/generic.py
@@ -186,20 +186,14 @@ class CoordinateSpace(NIDMObject):
             thresImgHdr = thresImg.get_header()
 
             numdim = len(thresImg.shape)
-            dimensions = str(thresImg.shape).replace(
-                '(', '[ ').replace(')', ' ]')
-            vox_to_world = '%s' \
-                % ', '.join(str(thresImg.get_qform())
-                            .strip('()')
-                            .replace('. ', '')
-                            .split()).replace('[,', '[').replace('\n', '')
-            vox_size = '[ %s ]' % ', '.join(
-                map(str, thresImgHdr['pixdim'][
-                    1:(self.number_of_dimensions + 1)]))
+            dimensions = thresImg.shape
+            # FIXME: is vox_to_world the qform?
+            vox_to_world = thresImg.get_qform()
+            vox_size = thresImgHdr['pixdim'][1:(numdim + 1)]
             # FIXME: this gives mm, sec => what is wrong: FSL file, nibabel,
             # other?
             # units = str(thresImgHdr.get_xyzt_units()).strip('()')
-            units = json.dumps(["mm", "mm", "mm"])
+            units = ["mm", "mm", "mm"]
 
         self.number_of_dimensions = numdim
         self.voxel_to_world = vox_to_world
@@ -238,12 +232,13 @@ class CoordinateSpace(NIDMObject):
         """
         self.add_attributes({
             PROV['type']: self.type,
-            NIDM_DIMENSIONS_IN_VOXELS: self.dimensions,
+            NIDM_DIMENSIONS_IN_VOXELS: json.dumps(self.dimensions),
             NIDM_NUMBER_OF_DIMENSIONS: self.number_of_dimensions,
-            NIDM_VOXEL_TO_WORLD_MAPPING: self.voxel_to_world,
+            NIDM_VOXEL_TO_WORLD_MAPPING:
+            json.dumps(self.voxel_to_world.tolist()),
             NIDM_IN_WORLD_COORDINATE_SYSTEM: self.coordinate_system,
-            NIDM_VOXEL_UNITS: self.units,
-            NIDM_VOXEL_SIZE: self.voxel_size,
+            NIDM_VOXEL_UNITS: json.dumps(self.units),
+            NIDM_VOXEL_SIZE: json.dumps(self.voxel_size.tolist()),
             PROV['label']: self.label})
         return self.p
 

--- a/nidmresults/objects/inference.py
+++ b/nidmresults/objects/inference.py
@@ -656,7 +656,7 @@ class Coordinate(NIDMObject):
 
         coordinate = {
             NIDM_COORDINATE_VECTOR_IN_VOXELS: json.dumps(self.coord_vector),
-            NIDM_COORDINATE_VECTOR: self.coord_vector_std,
+            NIDM_COORDINATE_VECTOR: json.dumps(self.coord_vector_std),
         }
 
         self.add_attributes(

--- a/nidmresults/objects/inference.py
+++ b/nidmresults/objects/inference.py
@@ -138,11 +138,13 @@ class ExcursionSet(NIDMObject):
                  export_dir=None, oid=None, format=None, label=None,
                  sha=None, filename=None, inference=None):
         super(ExcursionSet, self).__init__(export_dir, oid)
-        if location is None:
+        # Excursion set is going to be copied over to export_dir folder
+        if export_dir is not None:
             self.num = stat_num
             filename = 'ExcursionSet' + self.num + '.nii.gz'
         else:
             filename = location
+        self.filename = filename
         self.file = NIDMFile(self.id, location, filename, export_dir, sha)
         self.type = NIDM_EXCURSION_SET_MAP
         self.prov_type = PROV['Entity']


### PR DESCRIPTION
This PR is a fix to #19, identified when testing the FSL exporter against the updated nidmresults library, specifically it implements:
 - Conversion to json performed only when the `export` function is called (i.e. `CoordinateSpace` attributes are stored as python vectors and not json strings)
 - For the `ExcursionSet` object, the filename is the same as the file location only if `export_dir` is not defined (i.e. when reading a nidmpack not writing one)