### PR TITLE
Fix MKDA converter: contrast identifiers

### DIFF
--- a/bin/nidm_mkda_convert
+++ b/bin/nidm_mkda_convert
@@ -32,6 +32,7 @@ if __name__ == "__main__":
         outfile = outfile + ".csv"
 
     first = True
+    con_ids = dict()
     for nidmpack in nidmpacks:
         overwrite = False
         if first:
@@ -42,4 +43,5 @@ if __name__ == "__main__":
             raise Exception("Unknown file: "+str(nidmpack))
 
         nidmgraph = Graph(nidm_zip=nidmpack)
-        nidmgraph.serialize(outfile, "mkda", overwrite=overwrite)
+        con_ids = nidmgraph.serialize(
+            outfile, "mkda", overwrite=overwrite, con_ids=con_ids)

--- a/nidmresults/graph.py
+++ b/nidmresults/graph.py
@@ -398,7 +398,8 @@ ORDER BY ?peak_label
         self.objects.update(exc_sets)
         return exc_sets
 
-    def serialize(self, destination, format="mkda", overwrite=False):
+    def serialize(self, destination, format="mkda", overwrite=False,
+                  con_ids=dict()):
         # We need the peaks, excursion set maps and contrast maps
         self.get_peaks()
         self.get_excursion_set_maps()
@@ -429,7 +430,6 @@ ORDER BY ?peak_label
                 self.FixedRandom = "random"  # FIXME
 
                 # For anything that has a label
-                con_ids = dict()
                 con_ids[None] = 0
 
                 for oid, peak in self.get_peaks().items():
@@ -442,13 +442,13 @@ ORDER BY ?peak_label
 
                     stat_map = exc_set.inference.stat_map
 
-                    if stat_map.id in con_ids:
-                        con_id = con_ids[stat_map.id]
+                    con_name = stat_map.contrast_name.replace(" ", "_")
+
+                    if con_name in con_ids:
+                        con_id = con_ids[con_name]
                     else:
                         con_id = max(con_ids.values()) + 1
-                        con_ids[stat_map.id] = con_id
-
-                    con_name = stat_map.contrast_name.replace(" ", "_")
+                        con_ids[con_name] = con_id
 
                     writer.writerow([
                         peak.coordinate.coord_vector[0],
@@ -457,3 +457,5 @@ ORDER BY ?peak_label
                         con_id,
                         self.N, self.FixedRandom,
                         space, con_name])
+
+        return con_ids

--- a/nidmresults/graph.py
+++ b/nidmresults/graph.py
@@ -446,6 +446,7 @@ ORDER BY ?peak_label
                         con_id = con_ids[stat_map.id]
                     else:
                         con_id = max(con_ids.values()) + 1
+                        con_ids[stat_map.id] = con_id
 
                     con_name = stat_map.contrast_name.replace(" ", "_")
 

--- a/nidmresults/graph.py
+++ b/nidmresults/graph.py
@@ -421,7 +421,8 @@ ORDER BY ?peak_label
             with open(csvfile, open_mode) as fid:
                 writer = csv.writer(fid, delimiter='\t')
                 if add_header:
-                    writer.writerow(["9"])
+                    writer.writerow(["9", "NaN", "NaN", "NaN", "NaN", "NaN",
+                                     "NaN", "NaN", "NaN"])
                     writer.writerow(
                         ["x", "y", "z", "Study", "Contrast", "N",
                          "FixedRandom", "CoordSys", "Name"])


### PR DESCRIPTION
Following feedback from @AlexBowring, this PR fixes the NIDM-Results serialisation to an MKDA-compatible-csv-file, as follows:
 - Contrast identifier depends on contrast name instead of statistic id.
 - A list of contrast identifiers can be shared across serialisations (so that several studies targeting the same contrasts share the same contrast ids).