### PR TITLE
Comma removed

### DIFF
--- a/nidmresults/exporter.py
+++ b/nidmresults/exporter.py
@@ -113,7 +113,7 @@ class NIDMExporter():
             self.cleanup()
             raise
 
-    def cleanup(self,):
+    def cleanup(self):
         if os.path.isdir(self.export_dir):
             shutil.rmtree(self.export_dir)
 


### PR DESCRIPTION
This is a really quick PR. I'm not sure whether this could cause any errors but just in case I have removed a comma that was in the wrong place in this class definition. I doubt this is the cause but this does happen in the function in which the error reported in [issue 126](https://github.com/incf-nidash/nidmresults-fsl/issues/126) in the `nidmresults-fsl` repo occurs.