### PR TITLE
Fix source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
 include requirements.txt
 include nidmresults/prefixes.csv
+include owl/nidm-results_020.owl
+include owl/nidm-results_100.owl
+include owl/nidm-results_110.owl
+include owl/nidm-results_120.owl
+include owl/nidm-results_130.owl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include requirements.txt
 include nidmresults/prefixes.csv
-include owl/nidm-results_020.owl
-include owl/nidm-results_100.owl
-include owl/nidm-results_110.owl
-include owl/nidm-results_120.owl
-include owl/nidm-results_130.owl
+include nidmresults/owl/nidm-results_020.owl
+include nidmresults/owl/nidm-results_100.owl
+include nidmresults/owl/nidm-results_110.owl
+include nidmresults/owl/nidm-results_120.owl
+include nidmresults/owl/nidm-results_130.owl

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = list(filter(None, reqs))
 
 setup(
     name="nidmresults",
-    version="2.0.1-dev1",
+    version="2.0.0",
     author="Camille Maumet",
     author_email="c.m.j.maumet@warwick.ac.uk",
     description=(
@@ -33,8 +33,7 @@ setup(
                    'owl/nidm-results_100.owl',
                    'owl/nidm-results_110.owl',
                    'owl/nidm-results_120.owl',
-                   'owl/nidm-results_130.owl',
-                   'test/test_data.json']},
+                   'owl/nidm-results_130.owl']},
     include_package_data=True,
     install_requires=requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = list(filter(None, reqs))
 
 setup(
     name="nidmresults",
-    version="2.0.0",
+    version="2.0.1",
     author="Camille Maumet",
     author_email="c.m.j.maumet@warwick.ac.uk",
     description=(


### PR DESCRIPTION
This pull requests corrects a bug identified by @TomMaullin: when installing `nidmresults` from the tar.gz available on pypi (with python 2.7 under Ubuntu), the package did not include the owl files. 

This PR corrects this behavior by adding the owl files to the `MANIFEST.in` file.