### PR TITLE
BF: Add suffix to search space map to deal w/ mutliple masks

### DIFF
--- a/nidmresults/objects/inference.py
+++ b/nidmresults/objects/inference.py
@@ -911,10 +911,10 @@ class SearchSpace(NIDMObject):
                  extent_critical_fwe05=None, extent_critical_fdr05=None,
                  search_vol_geom=None, noise_roughness=None,
                  filename=None, sha=None, fmt=None,
-                 label=None, oid=None):
+                 label=None, oid=None, suffix=''):
         super(SearchSpace, self).__init__(oid=oid)
         if not filename:
-            filename = 'SearchSpaceMask.nii.gz'
+            filename = 'SearchSpaceMask' + suffix + '.nii.gz'
         self.file = NIDMFile(self.id, search_space_file, filename,
                              sha=sha, fmt=fmt)
         self.coord_space = coord_space


### PR DESCRIPTION
This PR is a fix to bug identified by @mih in https://github.com/incf-nidash/nidmresults-fsl/issues/148. In the presence of multiple analyses directories, all search space masks were written out to the same file `SearchSpaceMaskMap.nii.gz` leading to a "permission error". 

This PR updates the code to add a suffix to the search space file.